### PR TITLE
Move dev-deps to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,12 @@
     "license": "MIT",
     "dependencies": {
         "bluebird": "^3.5.0",
-        "request": "^2.81.0",
-        "@types/bluebird": "*",
-        "@types/request": "*",
-        "rewire": "^3.0.2"
+        "request": "^2.81.0"
     },
     "devDependencies": {
+        "@types/bluebird": "*",
         "@types/node": "8.10.34",
+        "@types/request": "*",
         "@typescript-eslint/eslint-plugin": "^4.20.0",
         "@typescript-eslint/parser": "^4.20.0",
         "eslint": "^7.23.0",


### PR DESCRIPTION
We required this module in our app and it brokes our TS compile using `ts-node` because the package `@types/bluebird` is required in the production dependencies and it does some trickery to the TS compiler.

Usually, @types are only used in package development and are not needed in production, so I did the following:

Moved to `devDependencies`:

* `@types/bluebird`
* `@types/request`

 and removed `rewire` because it was not used anywhere.

* rewire

If I missed something please let me know.